### PR TITLE
Full build

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You may want to edit the name assigned to the image in `docker-compose.yml` to i
    
       which is located [here](https://github.com/bu-ist/wp-manifests/blob/master/devl/jaydub-bulb.ini)
    
-   4. **REPOS:** This is a comma-delimited list of git repositories from the .ini file that are to be built into the wordpress installation of the image. *(An option for "all" repositories is not yet available, but will be coming)*. Example:
+   4. **REPOS:** This is a comma-delimited list of git repositories from the .ini file that are to be built into the wordpress installation of the image. Each repo must be locatable in the manifest ini file. To build ALL repositories in the manifest, simply omit this entry from the `.env` file. Example:
    
       ```
       responsive-framework-2-x, bu-cms, bu-sustainability, query-monitor

--- a/wordpress-build/Dockerfile
+++ b/wordpress-build/Dockerfile
@@ -15,8 +15,8 @@ COPY docker-entrypoint-build.sh /usr/local/bin/
 COPY wp-build.sh /usr/local/bin/
 
 RUN \
-  apt update && \
-  apt upgrade && \
+  apt update -y && \
+  apt upgrade -y && \
   apt install git wget dos2unix xxd -y && \
   mkdir -p /tmp/repos
 

--- a/wordpress-build/wp-build.sh
+++ b/wordpress-build/wp-build.sh
@@ -80,7 +80,7 @@ pullSvnRepo() {
     | sed -n '2 p')
 
   # "Pull" just the revision
-  wget -r $repo --accept-regex=.*/${path}/.*
+  wget -r $repo --accept-regex=.*/${path}/.* --reject=index.html*
 
   # Copy the content of the downloaded svn repo to the target directory.
   # The querystring portion of the revision is retained by wget on the end of the file names, so also strip these off while copying.
@@ -153,23 +153,56 @@ processSingleRepo() {
 
 # For each repos in REPOS, pull from the corresponding git repo and extract its content to the wp-content directory.
 processIniFile() {
-  # REPOS is a comma-delimited single line string. Iterate over each delimited value (repo).
-  for repo in $(echo "$REPOS" | awk 'BEGIN{RS = ","}{print $1}') ; do
+
+  processRepo() {
+    local repo=$1
 
     echo "Processing ${repo}..."
 
     loadSection $repo
 
     processSingleRepo  $repo
-  done
+
+  }
+  if [ -n "$REPOS" ] ; then
+    # REPOS is a comma-delimited single line string. Iterate over each delimited value (repo).
+    for repo in $(echo "$REPOS" | awk 'BEGIN{RS = ","}{print $1}') ; do
+      processRepo $repo
+    done
+  else
+    for repo in $(grep  -Po '(?<=\[)[^\]]+(?=\])' $inifile) ; do
+      processRepo $repo
+    done
+  fi
 }
 
 
+printDuration() {
+  local seconds=$((end-start))
+  [ -n "$1" ] && seconds=$1
+  let S=${seconds}%60
+  let MM=${seconds}/60 # Total number of minutes
+  let M=${MM}%60
+  let H=${MM}/60
+
+  # Display "01h02m03s" format
+  [ "$H" -gt "0" ] && printf "%02d%s" $H "h"
+  [ "$M" -gt "0" ] && printf "%02d%s" $M "m"
+  printf "Build duration: %02d%s\n" $S "s"
+}
+
 build() {
+
+  start=$(date +%s)
 
   pullManifestRepo
 
   processIniFile
+
+  end=$(date +%s)
+
+  printDuration
 }
+
 
 build

--- a/wordpress-build/wp-build.sh
+++ b/wordpress-build/wp-build.sh
@@ -79,8 +79,8 @@ pullSvnRepo() {
     | awk 'BEGIN {RS="/"} {if($1 != "") print $1}' \
     | sed -n '2 p')
 
-  # "Pull" just the revision
-  wget -r $repo --accept-regex=.*/${path}/.* --reject=index.html*
+  # "Pull" just the revision (Make sure level=0, which allows for infinite recursion, as opposed to the default depth of 5)
+  wget -r --level 0 $repo --accept-regex=.*/${path}/.* --reject=index.html*
 
   # Copy the content of the downloaded svn repo to the target directory.
   # The querystring portion of the revision is retained by wget on the end of the file names, so also strip these off while copying.


### PR DESCRIPTION
Hi Jon.
This will merges in changes that allow all repos within a manifest file to be built into the docker image.
Before, a comma-delimited list defined what repos within that manifest file were to be built, which is still available, but now you can simple omit that list to infer that you want ALL the repos in the list to be built.

What's not included is that second comma delimited list that indicates what repos you DO NOT want built (the inverse).
That will come in a separate pull request.

Don't forget to squash merge the commits in this branch:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits