### PR TITLE
Fix access key config extra

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,8 @@ services:
         define('SUBDOMAIN_INSTALL', false);
         define( 'S3_UPLOADS_BUCKET', '${S3_UPLOADS_BUCKET}');
         define( 'S3_UPLOADS_REGION', '${S3_UPLOADS_REGION}');
-        define( 'S3_UPLOADS_SECRET', '${S3_UPLOADS_SECRET}');
-        define( 'S3_UPLOADS_KEY', '${S3_UPLOADS_KEY}');
+        define( 'S3_UPLOADS_SECRET', '${S3_UPLOADS_SECRET_ACCESS_KEY}');
+        define( 'S3_UPLOADS_KEY', '${S3_UPLOADS_ACCESS_KEY_ID}');
         define( 'ACCESS_RULES_TABLE', '${ACCESS_RULES_TABLE}');
         define( 'S3_UPLOADS_OBJECT_ACL', null);
         define( 'S3_UPLOADS_AUTOENABLE', true );


### PR DESCRIPTION
Changes the env variable reference to match what is already set for the s3 signing container. This correctly gets the same key into the wp-config.php, where various plugins need it.
