### PR TITLE
Move global authtype to wordpress.conf

### DIFF
--- a/wordpress-baseline/shib.conf
+++ b/wordpress-baseline/shib.conf
@@ -23,13 +23,3 @@ ShibCompatValidUser Off
   </Location>
   Alias /shibboleth-sp/main.css /usr/share/shibboleth/main.css
 </IfModule>
-
-# This location adds shibboleth header for everything.
-# It doesn't require an active session however, it leaves that up the WordPress and PHP.
-# It also crucially requires shibboleth headers, with puts them into all S3 proxy requests.
-<Location />
-  AuthType Shibboleth
-  ShibRequestSetting requireSession false
-  Require shibboleth
-  ShibUseHeaders On
-</Location>

--- a/wordpress-baseline/wordpress.conf
+++ b/wordpress-baseline/wordpress.conf
@@ -35,3 +35,13 @@
   DocumentRoot /var/www/html
   
 </VirtualHost>
+
+# This Location directive adds the Shibboleth AuthType for all requests.
+# It doesn't require an active session however, it leaves that up the WordPress and PHP.
+# It also crucially requires shibboleth headers, with puts them into all S3 proxy requests.
+<Location />
+  AuthType Shibboleth
+  ShibRequestSetting requireSession false
+  Require shibboleth
+  ShibUseHeaders On
+</Location>


### PR DESCRIPTION
The configuration here seems more application specific. 

This is where shib headers are specifically added to everything so they are available to mod_proxy.
