### PR TITLE
Add awscli

### DIFF
--- a/wordpress-baseline/Dockerfile
+++ b/wordpress-baseline/Dockerfile
@@ -3,7 +3,7 @@ FROM wordpress:5.4.2-php7.4-apache
 # Client utils & tools
 RUN \
   apt update && apt upgrade; \
-  apt install curl less git vim dos2unix ssl-cert util-linux jq -y; \
+  apt install curl less git vim dos2unix ssl-cert util-linux jq unzip groff -y; \
   curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar; \
   chmod +x wp-cli.phar; \
   mv wp-cli.phar /usr/local/bin/wp; \

--- a/wordpress-baseline/Dockerfile
+++ b/wordpress-baseline/Dockerfile
@@ -12,8 +12,9 @@ RUN \
 
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
-    unzip awscliv2.zip && \
-	./aws/install
+  unzip -q awscliv2.zip && \
+  ./aws/install && \
+  rm awscliv2.zip && rm -rf aws/
 
 # Igbinary
 RUN \

--- a/wordpress-baseline/Dockerfile
+++ b/wordpress-baseline/Dockerfile
@@ -10,6 +10,11 @@ RUN \
   apt install -y $(apt-cache search mysql-client | head -1 | awk '{print $1}'); \
   docker-php-ext-install pdo pdo_mysql;
 
+# Install AWS CLI
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+	./aws/install
+
 # Igbinary
 RUN \
   mkdir -p /usr/src/php/ext \


### PR DESCRIPTION
Installs the AWS CLI binary as [recommended by AWS docs](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).

Generally useful, but also the BU `site-manager` WordPress plugin relies on running `aws s3` commands in a bash shell using php's `exec()` function for things like long running file copies.
