### PR TITLE
Add custom apache error handling for the S3 proxy responses

### DIFF
--- a/wordpress-baseline/Dockerfile
+++ b/wordpress-baseline/Dockerfile
@@ -52,6 +52,9 @@ COPY --chmod=766 shib.conf /etc/apache2/conf-available/
 COPY --chmod=700 healthcheck.htm /usr/src/wordpress/
 RUN rm /etc/apache2/sites-enabled/000-default.conf
 
+# Add custom error pages
+COPY --chmod=766 _s3proxy-custom-errors /var/www/html/_s3proxy-custom-errors
+
 # Custom htaccess file for multisite
 COPY --chmod=766 .htaccess /var/www/html/
 

--- a/wordpress-baseline/_s3proxy-custom-errors/401-unauthorized.php
+++ b/wordpress-baseline/_s3proxy-custom-errors/401-unauthorized.php
@@ -1,0 +1,15 @@
+<?php
+// Calculate the URL to redirect to the login page.
+$login_url = $_SERVER['Shib-Handler'] . '/Login?target=' . rawurlencode( $_SERVER['SCRIPT_URI'] );
+?>
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<html><head>
+<title>401 Unauthorized</title>
+<meta http-equiv="refresh" content="0; URL='<?php echo $login_url ?>'" />
+</head><body>
+<h1>401 Unauthorized</h1>
+<p>
+    You have requested a restricted resource ( <?php echo $_SERVER['REQUEST_URI'] ?> ), but are not logged in. 
+    <a href="<?php echo $login_url ?>">Log in to see protected content</a>
+</p>
+</body></html>

--- a/wordpress-baseline/_s3proxy-custom-errors/403-forbidden.php
+++ b/wordpress-baseline/_s3proxy-custom-errors/403-forbidden.php
@@ -1,0 +1,7 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<html><head>
+<title>403 Forbidden</title>
+</head><body>
+<h1>403 Forbidden</h1>
+<p>You don't have permission to access the resource at <?php echo $_SERVER['REDIRECT_SCRIPT_URL'] ?></p>  
+</body></html>

--- a/wordpress-baseline/_s3proxy-custom-errors/404-not-found.php
+++ b/wordpress-baseline/_s3proxy-custom-errors/404-not-found.php
@@ -1,0 +1,7 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<html><head>
+<title>404 Not Found</title>
+</head><body>
+<h1>404 Not Found</h1>
+<p>The requested URL <?php echo $_SERVER['REDIRECT_SCRIPT_URL'] ?> was not found on this server.</p>
+</body></html>

--- a/wordpress-build/s3proxy.conf
+++ b/wordpress-build/s3proxy.conf
@@ -11,3 +11,10 @@ RequestHeader unset X-Amzn-Trace-Id
   ProxyPass "S3PROXY_HOST_PLACEHOLDER"
   ProxyPassReverse [L]
 </Location>
+
+# Define custom error pages for proxy errors
+ProxyErrorOverride On
+
+ErrorDocument 401 /_s3proxy-custom-errors/401-unauthorized.php
+ErrorDocument 403 /_s3proxy-custom-errors/403-forbidden.php
+ErrorDocument 404 /_s3proxy-custom-errors/404-not-found.php


### PR DESCRIPTION
Adds custom error handling to the Apache proxy responses for the S3 proxy. Includes a login redirect (through a meta refresh tag) for 401 Unauthorized responses.

Note: the custom error pages are being added to the baseline image because that seems like the most appropriate place. The S3 proxy Apache config is in the build phase, but it refers to the custom error pages in the baseline image.