### PR TITLE
Target the right architecture for aws-cli

### DIFF
--- a/wordpress-baseline/Dockerfile
+++ b/wordpress-baseline/Dockerfile
@@ -1,5 +1,8 @@
 FROM wordpress:5.4.2-php7.4-apache
 
+# Set ARG for architecture
+ARG TARGETARCH
+
 # Client utils & tools
 RUN \
   apt update && apt upgrade; \
@@ -11,7 +14,11 @@ RUN \
   docker-php-ext-install pdo pdo_mysql;
 
 # Install AWS CLI
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+  curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"; \
+  else \
+  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
+  fi && \
   unzip -q awscliv2.zip && \
   ./aws/install && \
   rm awscliv2.zip && rm -rf aws/


### PR DESCRIPTION
This change tracks the processor architecture of the image based on the TARGETARCH property. 

If the current architecture is ARM based, it will download the ARM version of the AWS CLI. Otherwise it will download the Intel version.

With this change, the right binary will get installed when building on Macs with M-series processors. It also could open up the potential to use ARM based app containers, which tend to be less expensive to run.
